### PR TITLE
fix `imread` deprecation error in Scipy

### DIFF
--- a/image2numpy_imagenet_train.py
+++ b/image2numpy_imagenet_train.py
@@ -3,7 +3,7 @@
 from argparse import ArgumentParser
 from utils import *
 import os
-from matplotlib.pyplot import imread
+from imageio import imread
 import numpy as np
 
 def parse_arguments():

--- a/image2numpy_imagenet_train.py
+++ b/image2numpy_imagenet_train.py
@@ -6,6 +6,10 @@ import os
 from imageio import imread
 import numpy as np
 
+from PIL import PngImagePlugin
+LARGE_ENOUGH_NUMBER = 100
+PngImagePlugin.MAX_TEXT_CHUNK = LARGE_ENOUGH_NUMBER * (1024**2)
+
 def parse_arguments():
     parser = ArgumentParser()
     parser.add_argument('-i', '--in_dir', help="Input directory with source images")

--- a/image2numpy_imagenet_train.py
+++ b/image2numpy_imagenet_train.py
@@ -3,7 +3,7 @@
 from argparse import ArgumentParser
 from utils import *
 import os
-from scipy import misc
+from matplotlib.pyplot import imread
 import numpy as np
 
 def parse_arguments():
@@ -35,7 +35,7 @@ def process_folder(in_dir, out_dir):
         images = []
         for image_name in os.listdir(os.path.join(in_dir, folder)):
             try:
-                img = misc.imread(os.path.join(in_dir, folder, image_name))
+                img = imread(os.path.join(in_dir, folder, image_name))
                 r = img[:, :, 0].flatten()
                 g = img[:, :, 1].flatten()
                 b = img[:, :, 2].flatten()

--- a/image2numpy_imagenet_val.py
+++ b/image2numpy_imagenet_val.py
@@ -3,7 +3,7 @@
 from argparse import ArgumentParser
 import numpy as np
 import os
-from scipy import misc
+from matplotlib.pyplot import imread
 from utils import *
 
 
@@ -45,7 +45,7 @@ def process_folder(in_dir, out_dir):
         if label not in labels_searched:
             continue
         try:
-            img = misc.imread(os.path.join(in_dir, image_name))
+            img = imread(os.path.join(in_dir, image_name))
             r = img[:, :, 0].flatten()
             g = img[:, :, 1].flatten()
             b = img[:, :, 2].flatten()

--- a/image2numpy_imagenet_val.py
+++ b/image2numpy_imagenet_val.py
@@ -3,7 +3,7 @@
 from argparse import ArgumentParser
 import numpy as np
 import os
-from matplotlib.pyplot import imread
+from imageio import imread
 from utils import *
 
 

--- a/image2numpy_imagenet_val.py
+++ b/image2numpy_imagenet_val.py
@@ -6,6 +6,9 @@ import os
 from imageio import imread
 from utils import *
 
+from PIL import PngImagePlugin
+LARGE_ENOUGH_NUMBER = 100
+PngImagePlugin.MAX_TEXT_CHUNK = LARGE_ENOUGH_NUMBER * (1024**2)
 
 def parse_arguments():
     parser = ArgumentParser()


### PR DESCRIPTION
Fix #9 
Use `imageio.imread` instead